### PR TITLE
Update Go version to 1.24

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.19
+        go-version: 1.24
 
     - name: Client
       run: go build -o client -v ./cmd/client/main.go

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/maa123/WebSocketCraft
 
-go 1.16
+go 1.24
 
 require github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
Fixes #12

Update Go version to 1.24

* Update the Go version in `go.mod` file from 1.16 to 1.24
* Update the `go-version` in `.github/workflows/go.yml` file from 1.19 to 1.24

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/maa123/WebSocketCraft/pull/13?shareId=c6cad33e-902c-42e1-8341-1ac22992780f).